### PR TITLE
Add jq version check in azure kube-up

### DIFF
--- a/cluster/azure/util.sh
+++ b/cluster/azure/util.sh
@@ -37,6 +37,17 @@ source "${KUBE_ROOT}/cluster/common.sh"
 AZKUBE_VERSION="v0.0.5"
 REGISTER_MASTER_KUBELET="true"
 
+function ensure-jq-min-version() {
+    jq_version_string=$(eval "$(which jq) --version")
+    jq_version=${jq_version_string/jq-/}
+    jq_min_version=1.4
+
+    if (( $(bc <<< "$jq_version < $jq_min_version") )) ; then
+        echo "jq version must be at least at version $jq_min_version"
+        exit 1
+    fi
+}
+
 function verify-prereqs() {
     required_binaries=("docker" "jq")
 
@@ -219,6 +230,7 @@ function kube-up {
     echo "++> AZURE KUBE-UP STARTED: $(date)"
 
     verify-prereqs
+    ensure-jq-min-version
     azure-ensure-config
 
     if [[ -z "${AZURE_HYPERKUBE_SPEC:-}" ]]; then


### PR DESCRIPTION
<!--
Checklist for submitting a Pull Request

Please remove this comment block before submitting.

1. Please read our [contributor guidelines](https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md).
2. See our [developer guide](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md).
3. If you want this PR to automatically close an issue when it is merged,
   add `fixes #<issue number>` or `fixes #<issue number>, fixes #<issue number>`
   to close multiple issues (see: https://github.com/blog/1506-closing-issues-via-pull-requests).
4. Follow the instructions for [labeling and writing a release note for this PR](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes) in the block below.
-->

``` release-note
* Use the release-note-* labels to set the release note state 
* Clear this block to use the PR title as the release note 
-OR-
* Enter your extended release note here (newlines are formatted as bullets)
```

My version of jq I got from azure apt-get was out of date (azure ubuntu repository issue with my azure ubuntu vm which appears to be fixed) however this caused me to get the below error:

error: indices is not defined
.tags | indices(["v1.3.3"]) | any
        ^^^^^^^
error: any is not defined
.tags | indices(["v1.3.3"]) | any

I added a jq version checker as a start.
